### PR TITLE
Fixing auto gensym

### DIFF
--- a/Fennel.sublime-syntax
+++ b/Fennel.sublime-syntax
@@ -87,7 +87,7 @@ contexts:
       push: pop-string-tail
     - match: \#
       scope: entity.name.tag.literal_shorthand.fennel
-    - match: '[^:\s](\#)'
+    - match: '[^:\s"](\#)'
       captures:
         1: storage.type.auto_gensym.fennel
     - match: '{{lua_variables}}|{{lua_functions}}'
@@ -307,7 +307,7 @@ contexts:
         - match: \[
           scope: punctuation.section.brackets.begin.fennel
           set: pop-let-first-block
-        - match: .(\#)
+        - match: '[^:\s"](\#)'
           captures:
             1: storage.type.auto_gensym.fennel
         - match: ','
@@ -320,7 +320,7 @@ contexts:
     - include: match-expr
 
   pop-let-first-block:
-    - match: .(\#)
+    - match: '[^:\s"](\#)'
       captures:
         1: storage.type.auto_gensym.fennel
     - match: ','
@@ -334,7 +334,7 @@ contexts:
     - include: bind-operators
 
   pop-let-list-tail:
-    - match: .(\#)
+    - match: '[^:\s"](\#)'
       captures:
         1: storage.type.auto_gensym.fennel
     - match: ','

--- a/tests/syntax_test_fennel_extended.fnl
+++ b/tests/syntax_test_fennel_extended.fnl
@@ -245,3 +245,15 @@
 ;      ^ punctuation.definition.numeric.sign.fennel
 ;       ^^ constant.numeric.integer.decimal.fennel
 ;         ^ punctuation.section.parens.end.fennel
+
+(let [hex "#34a2eb"] true)
+; <- punctuation.section.parens.begin.fennel
+;^^^ entity.name.tag.let.fennel
+;    ^ punctuation.section.brackets.begin.fennel
+;     ^^^ source.fennel
+;         ^ punctuation.definition.string.begin.fennel
+;          ^^^^^^^ string.quoted.double.fennel
+;                 ^ punctuation.definition.string.end.fennel
+;                  ^ punctuation.section.brackets.end.fennel
+;                    ^^^^ constant.language.fennel
+;                        ^ punctuation.section.parens.end.fennel


### PR DESCRIPTION
> _Appending a # on the end of the identifier name as above invokes “auto gensym” which guarantees the local name is unique._