### PR TITLE
Adding support for Fennel 1.1.0

### DIFF
--- a/Fennel.sublime-completions
+++ b/Fennel.sublime-completions
@@ -1,7 +1,7 @@
 {
   "scope": "source.fennel",
   "completions": [
-    // Lua 5.4.0
+    // Lua 5.4.4
     "_G",
     "_VERSION",
 
@@ -179,29 +179,34 @@
     "utf8.len",
     "utf8.offset",
 
-    // Fennel 0.5.0
-    "not=",
+    // Fennel 1.1.0
+    ":until",
+    ":into",
     "band",
+    "_ENV",
     "bnot",
+    "accumulate",
     "bor",
     "bxor",
-    "doc",
+    "collect",
     "dotimes",
     "doto",
     "each",
     "eval-compiler",
-    "global",
     "hashfn",
+    "icollect",
     "import-macros",
     "include",
     "length",
     "lshift",
+    "match-try",
+    "catch",
     "macro",
     "macrodebug",
     "macros",
     "match",
+    "not=",
     "partial",
-    "pick-args",
     "pick-values",
     "println",
     "rshift",
@@ -211,13 +216,41 @@
     "values",
     "var",
     "when",
-    "with-open"
+    "where",
+    "with-open",
+
+    "fennel.comment",
+    "fennel.comment?",
+    "fennel.compile",
+    "fennel.compile-stream",
+    "fennel.compile-string",
+    "fennel.doc",
+    "fennel.dofile",
+    "fennel.eval",
+    "fennel.list",
+    "fennel.list?",
+    "fennel.load-code",
+    "fennel.macro-loaded",
+    "fennel.macro-path",
+    "fennel.macro-searchers",
+    "fennel.make-searcher",
+    "fennel.metadata",
+    "fennel.parser",
+    "fennel.path",
+    "fennel.repl",
+    "fennel.runtime-version",
+    "fennel.search-module",
+    "fennel.searcher",
+    "fennel.sequence",
+    "fennel.sequence?",
+    "fennel.sym",
+    "fennel.sym-char?",
+    "fennel.sym?",
+    "fennel.syntax",
+    "fennel.traceback",
+    "fennel.varg",
+    "fennel.varg?",
+    "fennel.view"
   ]
 }
-
-
-
-
-
-
 

--- a/Fennel.sublime-syntax
+++ b/Fennel.sublime-syntax
@@ -17,21 +17,22 @@ variables:
   lua_string: 'string\.(byte|char|dump|find|format|gmatch|gsub|len|lower|match|packsize|pack|rep|reverse|sub|unpack|upper)'
   lua_table: 'table\.(concat|insert|move|pack|remove|sort|unpack)'
   lua_utf8: 'utf8\.(charpattern|char|codepoint|codes|len|offset)'
+  fennel_api: '(fennel)\.(comment\?|comment|compile|compile-stream|compile-string|doc|dofile|eval|list\?|list|load-code|macro-loaded|macro-path|macro-searchers|make-searcher|metadata|parser|path|repl|runtime-version|search-module|searcher|sequence\?|sequence|sym-char\?|sym\?|sym|syntax|traceback|varg\?|varg|view)'
 
-  lua_variables: '_G|_VERSION|{{lua_coroutine}}|coroutine|{{lua_debug}}|debug|{{lua_io}}|io|{{lua_math}}|math|{{lua_os}}|os|{{lua_package}}|package|{{lua_string}}|string|{{lua_table}}|table|{{lua_utf8}}|utf8'
+  lua_variables: '_G|_ENV|_VERSION|_V|{{lua_coroutine}}|coroutine|{{lua_debug}}|debug|{{lua_io}}|io|{{lua_math}}|math|{{lua_os}}|os|{{lua_package}}|package|{{lua_string}}|string|{{lua_table}}|table|{{lua_utf8}}|utf8'
   lua_functions: 'assert|collectgarbage|dofile|error|getmetatable|ipairs|loadfile|load|next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|require|select|setmetatable|tonumber|tostring|type|warn|xpcall|{{lua_coroutine}}|{{lua_debug}}|{{lua_io}}|{{lua_math}}|{{lua_os}}|{{lua_package}}|{{lua_string}}|{{lua_table}}|{{lua_utf8}}'
 
   # -------------------------------------------------
 
   lua_constants: 'true|false|nil'
   lua_keywords: 'and|if|not|or|while|do|for'
-  lua_operators: '\+|\-|\%|\*|\/\/|\/|\^|\.\.|\>|\<|\>=|\<=|=|\.|\:|\.\.\.'
+  lua_operators: '\+|\-|\%|\*|\/\/|\/|\^|\.\.|\?\.|\>|\<|\>=|\<=|=|\.|\:|\.\.\.'
 
   # -------------------------------------------------
 
   fennel_threading_macros: (?:->|-\?>>|-\?>|-\>\>)(?=[{{non_symbol_chars}}])
   fennel_operators: 'not='
-  fennel_keywords: 'band|bnot|bor|bxor|doc|dotimes|doto|each|eval-compiler|global|hashfn|import-macros|include|length|lshift|macro|macrodebug|macros|match|partial|pick-args|pick-values|println|rshift|set|tset|unpack|values|var|when|with-open'
+  fennel_keywords: 'band|bnot|bor|bxor|dotimes|doto|each|where|icollect|collect|accumulate|eval-compiler|hashfn|import-macros|include|length|lshift|macro|macrodebug|macros|match-try|catch|match|partial|pick-values|println|rshift|set|tset|unpack|values|var|when|with-open'
   # -------------------------------------------------
 
   non_symbol_chars: \s,;\(\)\[\]{}\"`~@\^\\
@@ -45,7 +46,7 @@ variables:
   keyword: (:):?[^:{{non_symbol_chars}}][^{{non_symbol_chars}}]*
   constant: (?:{{lua_constants}})(?=[{{non_symbol_chars}}])
   lua_support: (?:{{lua_operators}}|{{lua_keywords}}|{{lua_functions}})(?=[{{non_symbol_chars}}])
-  fennel_support: (?:{{fennel_operators}}|{{fennel_keywords}})(?=[{{non_symbol_chars}}])
+  fennel_support: (?:{{fennel_operators}}|{{fennel_keywords}}|{{fennel_api}})(?=[{{non_symbol_chars}}])
   evil_octal: '[-+]?0\d+N?(?=[{{non_symbol_chars}}])'
   sign: '[-+]?'
   exponent: (?:[eE]{{sign}}\d+)
@@ -73,7 +74,9 @@ contexts:
           scope: punctuation.section.brackets.end.fennel
           pop: true
         - include: match-expr
-    - match: '#?{'
+    - match: '(#)?{'
+      captures:
+        1: entity.name.tag.literal_shorthand.fennel
       scope: punctuation.section.braces.begin.fennel
       push:
         - match: '}'
@@ -95,6 +98,14 @@ contexts:
     - match: '\?'
       scope: variable.function.optional.fennel
       push: pop-expr
+    - match: '\$(\.\.\.)'
+      scope: variable.function.hash_shorthand.fennel
+      captures:
+        1: keyword.operator.varargs.fennel
+    - match: '\$(\.)'
+      scope: variable.function.hash_shorthand.fennel
+      captures:
+        1: entity.name.tag.lua_support.fennel
     - match: '\$'
       scope: variable.function.hash_shorthand.fennel
     - match: '''|`|~|@'
@@ -249,7 +260,7 @@ contexts:
     - match: let\*?(?=[{{non_symbol_chars}}])
       scope: entity.name.tag.let.fennel
       set: pop-let-list-head
-    - match: (local|global)\*?(?=[{{non_symbol_chars}}])
+    - match: (local)\*?(?=[{{non_symbol_chars}}])
       scope: entity.name.tag.binding.fennel
       set: pop-binding-list-head
     - match: (?=\S)
@@ -348,7 +359,7 @@ contexts:
     - include: match-expr
 
   bind-operators:
-    - match: '\s(:|&)\s'
+    - match: '\s(:|&|&as)\s'
       scope: keyword.operator.bind.fennel
 
   pop-invoke-list-tail:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > _"Fennel is a programming language that brings together the speed, simplicity, and reach of Lua with the flexibility of a lisp syntax and macro system." [fennel-lang.org](https://fennel-lang.org)_
 
-Heavily tested against [Fennel 0.5.0](https://github.com/gbaptista/sublime-text-fennel/blob/master/tests/syntax_test_fennel_reference.fnl) and [Lua 5.4.0](https://github.com/gbaptista/sublime-text-fennel/blob/master/tests/syntax_test_lua.fnl) specifications.
+Heavily tested against [Fennel 1.1.0](https://github.com/gbaptista/sublime-text-fennel/blob/master/tests/syntax_test_fennel_reference.fnl) and [Lua 5.4.4](https://github.com/gbaptista/sublime-text-fennel/blob/master/tests/syntax_test_lua.fnl) specifications.
 
 ![Screenshot of a Fennel code highlighted.](https://raw.githubusercontent.com/gbaptista/sublime-text-fennel/master/screenshots/material-theme-darker/03.png)
 
@@ -18,10 +18,11 @@ Heavily tested against [Fennel 0.5.0](https://github.com/gbaptista/sublime-text-
   -  [Solarized (Light)](#solarized-light-screenshots)
   -  [Completions](#completions-screenshots)
   -  [Snippets](#snippets-screenshots)
+- [Development](#development)
 
 ## Completions
 
-One hundred ninety-four completions are available for _Fennel 0.5.0_ and _Lua 5.4.0_.
+One hundred ninety-four completions are available for _Fennel 1.1.0_ and _Lua 5.4.4_.
 
 #### Fennel Completions
 
@@ -48,7 +49,7 @@ The [_Clojure Package_](https://github.com/sublimehq/Packages/tree/master/Clojur
 
 ## References
 - [Fennel Language Website](https://fennel-lang.org)
-  - [Fennel 0.5.0 Reference](https://fennel-lang.org/reference)
+  - [Fennel 1.1.0 Reference](https://fennel-lang.org/reference)
 - [Lua Language Website](http://www.lua.org/)
   - [Lua 5.4 Reference Manual](https://www.lua.org/manual/5.4)
 
@@ -91,3 +92,7 @@ The [_Clojure Package_](https://github.com/sublimehq/Packages/tree/master/Clojur
 ![Screenshot of a Fennel code highlighted.](https://raw.githubusercontent.com/gbaptista/sublime-text-fennel/master/screenshots/snippets/01.png)
 
 ![Screenshot of a Fennel code highlighted.](https://raw.githubusercontent.com/gbaptista/sublime-text-fennel/master/screenshots/snippets/02.png)
+
+## Development
+
+TODO

--- a/README.md
+++ b/README.md
@@ -92,7 +92,3 @@ The [_Clojure Package_](https://github.com/sublimehq/Packages/tree/master/Clojur
 ![Screenshot of a Fennel code highlighted.](https://raw.githubusercontent.com/gbaptista/sublime-text-fennel/master/screenshots/snippets/01.png)
 
 ![Screenshot of a Fennel code highlighted.](https://raw.githubusercontent.com/gbaptista/sublime-text-fennel/master/screenshots/snippets/02.png)
-
-## Development
-
-TODO

--- a/tests/syntax_test_fennel_api.fnl
+++ b/tests/syntax_test_fennel_api.fnl
@@ -1,0 +1,195 @@
+; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
+
+; Fennel 1.1.0 on Lua 5.4.4
+
+(fennel.comment a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;               ^ source.fennel
+;                ^ punctuation.section.parens.end.fennel
+
+(fennel.comment? a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                ^ source.fennel
+;                 ^ punctuation.section.parens.end.fennel
+
+(fennel.compile a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;               ^ source.fennel
+;                ^ punctuation.section.parens.end.fennel
+
+(fennel.compile-stream a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                      ^ source.fennel
+;                       ^ punctuation.section.parens.end.fennel
+
+(fennel.compile-string a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                      ^ source.fennel
+;                       ^ punctuation.section.parens.end.fennel
+
+(fennel.doc a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;           ^ source.fennel
+;            ^ punctuation.section.parens.end.fennel
+
+(fennel.dofile a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;              ^ source.fennel
+;               ^ punctuation.section.parens.end.fennel
+
+(fennel.eval a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;            ^ source.fennel
+;             ^ punctuation.section.parens.end.fennel
+
+(fennel.list a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;            ^ source.fennel
+;             ^ punctuation.section.parens.end.fennel
+
+(fennel.list? a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;             ^ source.fennel
+;              ^ punctuation.section.parens.end.fennel
+
+(fennel.load-code a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                 ^ source.fennel
+;                  ^ punctuation.section.parens.end.fennel
+
+(fennel.macro-loaded a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                    ^ source.fennel
+;                     ^ punctuation.section.parens.end.fennel
+
+(fennel.macro-path a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                  ^ source.fennel
+;                   ^ punctuation.section.parens.end.fennel
+
+(fennel.macro-searchers a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                       ^ source.fennel
+;                        ^ punctuation.section.parens.end.fennel
+
+(fennel.make-searcher a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                     ^ source.fennel
+;                      ^ punctuation.section.parens.end.fennel
+
+(fennel.metadata a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                ^ source.fennel
+;                 ^ punctuation.section.parens.end.fennel
+
+(fennel.parser a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;              ^ source.fennel
+;               ^ punctuation.section.parens.end.fennel
+
+(fennel.path a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;            ^ source.fennel
+;             ^ punctuation.section.parens.end.fennel
+
+(fennel.repl a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;            ^ source.fennel
+;             ^ punctuation.section.parens.end.fennel
+
+(fennel.runtime-version a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                       ^ source.fennel
+;                        ^ punctuation.section.parens.end.fennel
+
+(fennel.search-module a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                     ^ source.fennel
+;                      ^ punctuation.section.parens.end.fennel
+
+(fennel.searcher a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                ^ source.fennel
+;                 ^ punctuation.section.parens.end.fennel
+
+(fennel.sequence a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                ^ source.fennel
+;                 ^ punctuation.section.parens.end.fennel
+
+(fennel.sequence? a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                 ^ source.fennel
+;                  ^ punctuation.section.parens.end.fennel
+
+(fennel.sym a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;           ^ source.fennel
+;            ^ punctuation.section.parens.end.fennel
+
+(fennel.sym-char? a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                 ^ source.fennel
+;                  ^ punctuation.section.parens.end.fennel
+
+(fennel.sym? a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;            ^ source.fennel
+;             ^ punctuation.section.parens.end.fennel
+
+(fennel.syntax a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;              ^ source.fennel
+;               ^ punctuation.section.parens.end.fennel
+
+(fennel.traceback a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                 ^ source.fennel
+;                  ^ punctuation.section.parens.end.fennel
+
+(fennel.varg a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;            ^ source.fennel
+;             ^ punctuation.section.parens.end.fennel
+
+(fennel.varg? a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;             ^ source.fennel
+;              ^ punctuation.section.parens.end.fennel
+
+(fennel.view a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;            ^ source.fennel
+;             ^ punctuation.section.parens.end.fennel

--- a/tests/syntax_test_fennel_extended.fnl
+++ b/tests/syntax_test_fennel_extended.fnl
@@ -1,6 +1,6 @@
 ; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
 
-; Fennel 0.5.0 on Lua 5.4.0
+; Fennel 1.1.0 on Lua 5.4.4
 
 ; Hash function literal shorthand
 

--- a/tests/syntax_test_fennel_reference.fnl
+++ b/tests/syntax_test_fennel_reference.fnl
@@ -1,6 +1,6 @@
 ; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
 
-; Fennel 0.5.0 on Lua 5.4.0
+; Fennel 1.1.0 on Lua 5.4.0
 
 ; These are all the special forms recognized by the Fennel compiler. It does not include built-in Lua functions; see the Lua reference manual or the Lua primer for that.
 
@@ -170,6 +170,7 @@
 
 #[$1 $2 $3]       ; same as (fn [a b c] [a b c])
 ; <- entity.name.tag.literal_shorthand.fennel
+;^ punctuation.section.brackets.begin.fennel
 ; ^ variable.function.hash_shorthand.fennel
 ;  ^ constant.numeric.integer.decimal.fennel
 ;    ^ variable.function.hash_shorthand.fennel
@@ -427,7 +428,7 @@
 
 (pick-args 2 add) ; expands to `(fn [_0_ _1_] (add _0_ _1_))`
 ; <- punctuation.section.parens.begin.fennel
-;^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;^^^^^^^^^ variable.function.fennel
 ;          ^ constant.numeric.integer.decimal.fennel
 ;            ^^^ source.fennel
 ;               ^ punctuation.section.parens.end.fennel
@@ -447,7 +448,7 @@
 ;                ^^^^^^^^^^^^ entity.name.tag.lua_support.fennel
 ;                            ^ punctuation.section.parens.end.fennel
 ;                              ^^ punctuation.section.parens.begin.fennel
-;                                ^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                                ^^^^^^^^^ variable.function.fennel
 ;                                          ^ constant.numeric.integer.decimal.fennel
 ;                                            ^^^ source.fennel
 ;                                               ^^^ punctuation.section.parens.end.fennel
@@ -468,7 +469,7 @@
 ((pick-args 3 count-args) "still three args, but 2nd and 3rd are nil") ; => 3
 ; <- punctuation.section.parens.begin.fennel
 ;^ punctuation.section.parens.begin.fennel
-; ^^^^^^^^^ entity.name.tag.fennel_support.fennel
+; ^^^^^^^^^ variable.function.fennel
 ;           ^ constant.numeric.integer.decimal.fennel
 ;             ^^^^^^^^^^ source.fennel
 ;                       ^ punctuation.section.parens.end.fennel
@@ -927,7 +928,7 @@
 
 (global prettyprint (fn [x] (print (view x))))
 ; <- punctuation.section.parens.begin.fennel
-;^^^^^^ entity.name.tag.binding.fennel
+;^^^^^^ variable.function.fennel
 ;       ^^^^^^^^^^^ source.fennel
 ;                   ^ punctuation.section.parens.begin.fennel
 ;                    ^^ storage.modifier.fn.fennel
@@ -1083,7 +1084,7 @@
 ; TODO: Open a pull request to remove comma and fix variable name
 (global (x-m x-e) (math.frexp 21)) {:m x-m :e x-e} ;  => {:e 5 :m 0.65625}
 ; <- punctuation.section.parens.begin.fennel
-;^^^^^^ entity.name.tag.binding.fennel
+;^^^^^^ variable.function.fennel
 ;       ^ punctuation.section.parens.begin.fennel
 ;        ^^^^^^^ source.fennel
 ;               ^ punctuation.section.parens.end.fennel

--- a/tests/syntax_test_fennel_reference_110.fnl
+++ b/tests/syntax_test_fennel_reference_110.fnl
@@ -1,0 +1,264 @@
+; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
+
+; Fennel 1.1.0 on Lua 5.4.4
+
+; Deprecated:
+
+(doc a)
+; <- punctuation.section.parens.begin.fennel
+;^^^ variable.function.fennel
+;    ^ source.fennel
+;     ^ punctuation.section.parens.end.fennel
+
+(global a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^ variable.function.fennel
+;       ^ source.fennel
+;        ^ punctuation.section.parens.end.fennel
+
+(pick-args a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^ variable.function.fennel
+;          ^ source.fennel
+;           ^ punctuation.section.parens.end.fennel
+
+(match-> a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^ variable.function.fennel
+;        ^ source.fennel
+;         ^ punctuation.section.parens.end.fennel
+
+; New forms
+
+(collect [k v (pairs {:apple "red" :orange "orange"})]
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^ entity.name.tag.fennel_support.fennel
+;        ^ punctuation.section.brackets.begin.fennel
+;         ^^^ source.fennel
+;             ^ punctuation.section.parens.begin.fennel
+;              ^^^^^ entity.name.tag.lua_support.fennel
+;                    ^ punctuation.section.braces.begin.fennel
+;                     ^ punctuation.definition.keyword.fennel
+;                      ^^^^^ constant.other.keyword.fennel
+;                            ^ punctuation.definition.string.begin.fennel
+;                             ^^^ string.quoted.double.fennel
+;                                ^ punctuation.definition.string.end.fennel
+;                                  ^ punctuation.definition.keyword.fennel
+;                                   ^^^^^^ constant.other.keyword.fennel
+;                                          ^ punctuation.definition.string.begin.fennel
+;                                           ^^^^^^ string.quoted.double.fennel
+;                                                 ^ punctuation.definition.string.end.fennel
+;                                                  ^ punctuation.section.braces.end.fennel
+;                                                   ^ punctuation.section.parens.end.fennel
+;                                                    ^ punctuation.section.brackets.end.fennel
+  (.. "color-" v) k)
+; ^ punctuation.section.parens.begin.fennel
+;  ^^ entity.name.tag.lua_support.fennel
+;     ^ punctuation.definition.string.begin.fennel
+;      ^^^^^^ string.quoted.double.fennel
+;            ^ punctuation.definition.string.end.fennel
+;              ^ source.fennel
+;               ^ punctuation.section.parens.end.fennel
+;                 ^ source.fennel
+;                  ^ punctuation.section.parens.end.fennel
+
+
+(icollect [_ x (ipairs [2 3]) :into [9]]
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^ entity.name.tag.fennel_support.fennel
+;         ^ punctuation.section.brackets.begin.fennel
+;          ^^^^ source.fennel
+;              ^ punctuation.section.parens.begin.fennel
+;               ^^^^^^ entity.name.tag.lua_support.fennel
+;                      ^ punctuation.section.brackets.begin.fennel
+;                       ^ constant.numeric.integer.decimal.fennel
+;                         ^ constant.numeric.integer.decimal.fennel
+;                          ^ punctuation.section.brackets.end.fennel
+;                           ^ punctuation.section.parens.end.fennel
+;                             ^ punctuation.definition.keyword.fennel
+;                              ^^^^ constant.other.keyword.fennel
+;                                   ^ punctuation.section.brackets.begin.fennel
+;                                    ^ constant.numeric.integer.decimal.fennel
+;                                     ^^ punctuation.section.brackets.end.fennel
+  (* x 11))
+; ^ punctuation.section.parens.begin.fennel
+;  ^ entity.name.tag.lua_support.fennel
+;    ^ source.fennel
+;      ^^ constant.numeric.integer.decimal.fennel
+;        ^^ punctuation.section.parens.end.fennel
+
+(var x 0)
+; <- punctuation.section.parens.begin.fennel
+;^^^ entity.name.tag.fennel_support.fennel
+;    ^ source.fennel
+;      ^ constant.numeric.integer.decimal.fennel
+;       ^ punctuation.section.parens.end.fennel
+(for [i 1 128 :until (maxed-out? x)]
+; <- punctuation.section.parens.begin.fennel
+;^^^ entity.name.tag.lua_support.fennel
+;    ^ punctuation.section.brackets.begin.fennel
+;     ^ source.fennel
+;       ^ constant.numeric.integer.decimal.fennel
+;         ^^^ constant.numeric.integer.decimal.fennel
+;             ^ punctuation.definition.keyword.fennel
+;              ^^^^^ constant.other.keyword.fennel
+;                    ^ punctuation.section.parens.begin.fennel
+;                     ^^^^^^^^^^ variable.function.fennel
+;                                ^ source.fennel
+;                                 ^ punctuation.section.parens.end.fennel
+;                                  ^ punctuation.section.brackets.end.fennel
+  (set x (+ x i)))
+; ^ punctuation.section.parens.begin.fennel
+;  ^^^ entity.name.tag.fennel_support.fennel
+;      ^ source.fennel
+;        ^ punctuation.section.parens.begin.fennel
+;         ^ entity.name.tag.lua_support.fennel
+;           ^^^ source.fennel
+;              ^^^ punctuation.section.parens.end.fennel
+
+
+#{:a $1 :b $...}
+; <- entity.name.tag.literal_shorthand.fennel
+;^ punctuation.section.braces.begin.fennel
+; ^ punctuation.definition.keyword.fennel
+;  ^ constant.other.keyword.fennel
+;    ^ variable.function.hash_shorthand.fennel
+;     ^ constant.numeric.integer.decimal.fennel
+;       ^ punctuation.definition.keyword.fennel
+;        ^ constant.other.keyword.fennel
+;          ^ variable.function.hash_shorthand.fennel
+;           ^^^ keyword.operator.varargs.fennel
+;              ^ punctuation.section.braces.end.fennel
+
+#$.foo
+; <- entity.name.tag.literal_shorthand.fennel
+;^ variable.function.hash_shorthand.fennel
+; ^ entity.name.tag.lua_support.fennel
+;  ^^^ source.fennel
+
+(match-try a
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;          ^ source.fennel
+  a {:a a}
+; ^ source.fennel
+;   ^ punctuation.section.braces.begin.fennel
+;    ^ punctuation.definition.keyword.fennel
+;     ^ constant.other.keyword.fennel
+;       ^ source.fennel
+;        ^ punctuation.section.braces.end.fennel
+  (catch
+; ^ punctuation.section.parens.begin.fennel
+;  ^^^^^ entity.name.tag.fennel_support.fennel
+    (_ :timeout) nil))
+;   ^ punctuation.section.parens.begin.fennel
+;    ^ variable.function.fennel
+;      ^ punctuation.definition.keyword.fennel
+;       ^^^^^^^ constant.other.keyword.fennel
+;                ^^^ constant.language.fennel
+;                   ^^ punctuation.section.parens.end.fennel
+
+(let [{:a a :b b &as all} {:a 1 :b 2 :c 3 :d 4}]
+; <- punctuation.section.parens.begin.fennel
+;^^^ entity.name.tag.let.fennel
+;    ^ punctuation.section.brackets.begin.fennel
+;     ^ punctuation.section.braces.begin.fennel
+;      ^ punctuation.definition.keyword.fennel
+;       ^ constant.other.keyword.fennel
+;         ^ source.fennel
+;           ^ punctuation.definition.keyword.fennel
+;            ^ constant.other.keyword.fennel
+;              ^ source.fennel
+;                ^^^ keyword.operator.bind.fennel
+;                    ^^^ source.fennel
+;                       ^ punctuation.section.braces.end.fennel
+;                         ^ punctuation.section.braces.begin.fennel
+;                          ^ punctuation.definition.keyword.fennel
+;                           ^ constant.other.keyword.fennel
+;                             ^ constant.numeric.integer.decimal.fennel
+;                               ^ punctuation.definition.keyword.fennel
+;                                ^ constant.other.keyword.fennel
+;                                  ^ constant.numeric.integer.decimal.fennel
+;                                    ^ punctuation.definition.keyword.fennel
+;                                     ^ constant.other.keyword.fennel
+;                                       ^ constant.numeric.integer.decimal.fennel
+;                                         ^ punctuation.definition.keyword.fennel
+;                                          ^ constant.other.keyword.fennel
+;                                            ^ constant.numeric.integer.decimal.fennel
+;                                             ^ punctuation.section.braces.end.fennel
+;                                              ^ punctuation.section.brackets.end.fennel
+  (+ a b all.c all.d))
+; ^ punctuation.section.parens.begin.fennel
+;  ^ entity.name.tag.lua_support.fennel
+;    ^^^^^^^^^^^^^^^ source.fennel
+;                   ^^ punctuation.section.parens.end.fennel
+
+(accumulate [sum 0
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;           ^ punctuation.section.brackets.begin.fennel
+;            ^^^ source.fennel
+;                ^ constant.numeric.integer.decimal.fennel
+             i n (ipairs [10 20 30 40])]
+;            ^^^ source.fennel
+;                ^ punctuation.section.parens.begin.fennel
+;                 ^^^^^^ entity.name.tag.lua_support.fennel
+;                        ^ punctuation.section.brackets.begin.fennel
+;                         ^^ constant.numeric.integer.decimal.fennel
+;                            ^^ constant.numeric.integer.decimal.fennel
+;                               ^^ constant.numeric.integer.decimal.fennel
+;                                  ^^ constant.numeric.integer.decimal.fennel
+;                                    ^ punctuation.section.brackets.end.fennel
+;                                     ^ punctuation.section.parens.end.fennel
+;                                      ^ punctuation.section.brackets.end.fennel
+    (+ sum n))
+;   ^ punctuation.section.parens.begin.fennel
+;    ^ entity.name.tag.lua_support.fennel
+;      ^^^^^ source.fennel
+;           ^^ punctuation.section.parens.end.fennel
+
+
+(match [91 12 53]
+; <- punctuation.section.parens.begin.fennel
+;^^^^^ entity.name.tag.fennel_support.fennel
+;      ^ punctuation.section.brackets.begin.fennel
+;       ^^ constant.numeric.integer.decimal.fennel
+;          ^^ constant.numeric.integer.decimal.fennel
+;             ^^ constant.numeric.integer.decimal.fennel
+;               ^ punctuation.section.brackets.end.fennel
+  (where [a b c] (= 5 a)) :will-not-match
+; ^ punctuation.section.parens.begin.fennel
+;  ^^^^^ entity.name.tag.fennel_support.fennel
+;        ^ punctuation.section.brackets.begin.fennel
+;         ^^^^^ source.fennel
+;              ^ punctuation.section.brackets.end.fennel
+;                ^ punctuation.section.parens.begin.fennel
+;                 ^ entity.name.tag.lua_support.fennel
+;                   ^ constant.numeric.integer.decimal.fennel
+;                     ^ source.fennel
+;                      ^^ punctuation.section.parens.end.fennel
+;                         ^ punctuation.definition.keyword.fennel
+;                          ^^^^^^^^^^^^^^ constant.other.keyword.fennel
+  _ "will match anything else")
+; ^ source.fennel
+;   ^ punctuation.definition.string.begin.fennel
+;    ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.fennel
+;                            ^ punctuation.definition.string.end.fennel
+;                             ^ punctuation.section.parens.end.fennel
+
+
+(set _G.a 1)
+; <- punctuation.section.parens.begin.fennel
+;^^^ entity.name.tag.fennel_support.fennel
+;    ^^ variable.language.lua_constant.fennel
+;      ^^ source.fennel
+;         ^ constant.numeric.integer.decimal.fennel
+;          ^ punctuation.section.parens.end.fennel
+
+(set _ENV.a 2)
+; <- punctuation.section.parens.begin.fennel
+;^^^ entity.name.tag.fennel_support.fennel
+;    ^^^^ variable.language.lua_constant.fennel
+;        ^^ source.fennel
+;           ^ constant.numeric.integer.decimal.fennel
+;            ^ punctuation.section.parens.end.fennel

--- a/tests/syntax_test_lua.fnl
+++ b/tests/syntax_test_lua.fnl
@@ -1,6 +1,6 @@
 ; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
 
-; Fennel 0.5.0 on Lua 5.4.0
+; Fennel 1.1.0 on Lua 5.4.4
 
 ; 2 – Basic Concepts
 ; 2.1 – Values and Types


### PR DESCRIPTION
New:

```fnl
#{:a $1}

{:a a :b b &as all}
```

```fnl
:into :until _ENV accumulate collect icollect match-try where
```

Fennel Public API:

`fennel.eval`, `fennel.repl`, etc.


Deprecating:
```fnl
doc global match-> pick-args
```