### PR TITLE
updated for Fennel 1.6.1 and Lua 5.5

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -21,12 +21,12 @@ jobs:
       matrix:
         include:
           - build: 3211
-          - build: 4073
+          - build: stable
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
-      - uses: SublimeText/syntax-test-action@v1
+      - uses: actions/checkout@v4
+      - uses: SublimeText/syntax-test-action@v2
         with:
           build: ${{ matrix.build }}
           package_name: Fennel
-          package_root: sublime-text-fennel

--- a/Fennel.sublime-completions
+++ b/Fennel.sublime-completions
@@ -1,7 +1,7 @@
 {
   "scope": "source.fennel",
   "completions": [
-    // Lua 5.4.4
+    // Lua 5.5.0
     "_G",
     "_VERSION",
 
@@ -165,6 +165,7 @@
     "string.upper",
 
     "table.concat",
+    "table.create",
     "table.insert",
     "table.move",
     "table.pack",
@@ -179,7 +180,7 @@
     "utf8.len",
     "utf8.offset",
 
-    // Fennel 1.3.0
+    // Fennel 1.6.1
     "&as",
     ":until",
     "&until",
@@ -189,6 +190,7 @@
     "_ENV",
     "bnot",
     "accumulate",
+    "assert-repl",
     "bor",
     "bxor",
     "case",
@@ -218,6 +220,7 @@
     "println",
     "rshift",
     "set",
+    "tail!",
     "tset",
     "unpack",
     "values",
@@ -235,6 +238,7 @@
     "fennel.doc",
     "fennel.dofile",
     "fennel.eval",
+    "fennel.getinfo",
     "fennel.install",
     "fennel.list",
     "fennel.list?",
@@ -244,6 +248,7 @@
     "fennel.macro-searchers",
     "fennel.make-searcher",
     "fennel.metadata",
+    "fennel.multi-sym?",
     "fennel.parser",
     "fennel.path",
     "fennel.repl",

--- a/Fennel.sublime-syntax
+++ b/Fennel.sublime-syntax
@@ -5,6 +5,7 @@
 name: Fennel
 file_extensions:
   - fnl
+  - fnlm
 scope: source.fennel
 
 variables:
@@ -15,9 +16,9 @@ variables:
   lua_os: 'os\.(clock|date|difftime|execute|exit|getenv|remove|rename|setlocale|time|tmpname)'
   lua_package: 'package\.(config|cpath|loaded|loadlib|path|preload|searchers|searchpath)'
   lua_string: 'string\.(byte|char|dump|find|format|gmatch|gsub|len|lower|match|packsize|pack|rep|reverse|sub|unpack|upper)'
-  lua_table: 'table\.(concat|insert|move|pack|remove|sort|unpack)'
+  lua_table: 'table\.(concat|create|insert|move|pack|remove|sort|unpack)'
   lua_utf8: 'utf8\.(charpattern|char|codepoint|codes|len|offset)'
-  fennel_api: '(fennel)\.(ast-source|comment\?|comment|compile|compile-stream|compile-string|doc|dofile|eval|install|list\?|list|load-code|macro-loaded|macro-path|macro-searchers|make-searcher|metadata|parser|path|repl|runtime-version|search-module|searcher|sequence\?|sequence|sym-char\?|sym\?|sym|syntax|table\?|traceback|varg\?|varg|view)'
+  fennel_api: '(fennel)\.(ast-source|comment\?|comment|compile|compile-stream|compile-string|doc|dofile|eval|getinfo|install|list\?|list|load-code|macro-loaded|macro-path|macro-searchers|make-searcher|metadata|multi-sym\?|parser|path|repl|runtime-version|search-module|searcher|sequence\?|sequence|sym-char\?|sym\?|sym|syntax|table\?|traceback|varg\?|varg|view)'
 
   constants: '_G|_ENV|_VERSION|_V'
   lua_variables: '{{lua_coroutine}}|coroutine|{{lua_debug}}|debug|{{lua_io}}|io|{{lua_math}}|math|{{lua_os}}|os|{{lua_package}}|package|{{lua_string}}|string|{{lua_table}}|table|{{lua_utf8}}|utf8'
@@ -33,7 +34,7 @@ variables:
 
   fennel_threading_macros: (?:->|-\?>>|-\?>|-\>\>)(?=[{{non_symbol_chars}}])
   fennel_operators: 'not='
-  fennel_keywords: 'band|bnot|bor|bxor|dotimes|doto|each|where|fcollect|icollect|collect|faccumulate|accumulate|eval-compiler|hashfn|import-macros|include|length|lshift|macro|macrodebug|macros|case-try|match-try|catch|case|match|partial|pick-values|println|rshift|set|tset|unpack|values|var|when|with-open'
+  fennel_keywords: 'assert-repl|band|bnot|bor|bxor|dotimes|doto|each|where|fcollect|icollect|collect|faccumulate|accumulate|eval-compiler|hashfn|import-macros|include|length|lshift|macro|macrodebug|macros|case-try|match-try|catch|case|match|partial|pick-values|println|rshift|set|tail!|tset|unpack|values|var|when|with-open'
   # -------------------------------------------------
 
   non_symbol_chars: \s,;\(\)\[\]{}\"`~@\^\\

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Heavily tested against [Fennel 1.3.0](https://github.com/gbaptista/sublime-text-
 
 ## Completions
 
-One hundred ninety-nine completions are available for _Fennel 1.3.0_ and _Lua 5.4.4_.
+One hundred ninety-nine completions are available for _Fennel 1.6.1_ and _Lua 5.5.5_.
 
 #### Fennel Completions
 
@@ -53,9 +53,9 @@ One hundred ninety-nine completions are available for _Fennel 1.3.0_ and _Lua 5.
 
 ## References
 - [Fennel Language Website](https://fennel-lang.org)
-  - [Fennel 1.3.0 Reference](https://fennel-lang.org/reference)
+  - [Fennel Reference](https://fennel-lang.org/reference)
 - [Lua Language Website](http://www.lua.org/)
-  - [Lua 5.4 Reference Manual](https://www.lua.org/manual/5.4)
+  - [Lua 5.5 Reference Manual](https://www.lua.org/manual/5.5)
 
 ## Development
 

--- a/tests/syntax_test_fennel_api.fnl
+++ b/tests/syntax_test_fennel_api.fnl
@@ -1,6 +1,6 @@
 ; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
 
-; Fennel 1.3.0 on Lua 5.4.4
+; Fennel 1.6.1 on Lua 5.5.0
 
 (fennel.ast-source a)
 ; <- punctuation.section.parens.begin.fennel
@@ -56,6 +56,12 @@
 ;            ^ source.fennel
 ;             ^ punctuation.section.parens.end.fennel
 
+(fennel.getinfo a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;               ^ source.fennel
+;                ^ punctuation.section.parens.end.fennel
+
 (fennel.install a)
 ; <- punctuation.section.parens.begin.fennel
 ;^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
@@ -109,6 +115,12 @@
 ;^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
 ;                ^ source.fennel
 ;                 ^ punctuation.section.parens.end.fennel
+
+(fennel.multi-sym? a)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;                  ^ source.fennel
+;                   ^ punctuation.section.parens.end.fennel
 
 (fennel.parser a)
 ; <- punctuation.section.parens.begin.fennel

--- a/tests/syntax_test_fennel_reference.fnl
+++ b/tests/syntax_test_fennel_reference.fnl
@@ -1,6 +1,6 @@
 ; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
 
-; Fennel 1.3.0 on Lua 5.4.0
+; Fennel 1.1.0 on Lua 5.4.0
 
 ; These are all the special forms recognized by the Fennel compiler. It does not include built-in Lua functions; see the Lua reference manual or the Lua primer for that.
 

--- a/tests/syntax_test_fennel_reference_110.fnl
+++ b/tests/syntax_test_fennel_reference_110.fnl
@@ -1,6 +1,6 @@
 ; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
 
-; Fennel 1.3.0 on Lua 5.4.4
+; Fennel 1.1.0 on Lua 5.4.4
 
 ; Deprecated:
 
@@ -101,28 +101,6 @@ _1 7/8 1_
 ;      ^^ constant.numeric.integer.decimal.fennel
 ;        ^^ punctuation.section.parens.end.fennel
 
-(fcollect [i 0 10 2]
-; <- punctuation.section.parens.begin.fennel
-;^^^^^^^^ entity.name.tag.fennel_support.fennel
-;         ^ punctuation.section.brackets.begin.fennel
-;          ^ source.fennel
-;            ^ constant.numeric.integer.decimal.fennel
-;              ^^ constant.numeric.integer.decimal.fennel
-;                 ^ constant.numeric.integer.decimal.fennel
-;                  ^ punctuation.section.brackets.end.fennel
-  (if (> i 2) (* i i)))
-; ^ punctuation.section.parens.begin.fennel
-;  ^^ entity.name.tag.lua_support.fennel
-;     ^ punctuation.section.parens.begin.fennel
-;      ^ entity.name.tag.lua_support.fennel
-;        ^ source.fennel
-;          ^ constant.numeric.integer.decimal.fennel
-;           ^ punctuation.section.parens.end.fennel
-;             ^ punctuation.section.parens.begin.fennel
-;              ^ entity.name.tag.lua_support.fennel
-;                ^^^ source.fennel
-;                   ^^^ punctuation.section.parens.end.fennel
-
 (var x 0)
 ; <- punctuation.section.parens.begin.fennel
 ;^^^ entity.name.tag.fennel_support.fennel
@@ -221,28 +199,6 @@ _1 7/8 1_
 ;                     ^^^^^ constant.language.fennel
 ;                          ^ punctuation.section.parens.end.fennel
 
-(case-try a
-; <- punctuation.section.parens.begin.fennel
-;^^^^^^^^ entity.name.tag.fennel_support.fennel
-;         ^ source.fennel
-  a {:a a}
-; ^ source.fennel
-;   ^ punctuation.section.braces.begin.fennel
-;    ^ punctuation.definition.keyword.fennel
-;     ^ constant.other.keyword.fennel
-;       ^ source.fennel
-;        ^ punctuation.section.braces.end.fennel
-  (catch
-; ^ punctuation.section.parens.begin.fennel
-;  ^^^^^ entity.name.tag.fennel_support.fennel
-    (_ :timeout) nil))
-;   ^ punctuation.section.parens.begin.fennel
-;    ^ variable.function.fennel
-;      ^ punctuation.definition.keyword.fennel
-;       ^^^^^^^ constant.other.keyword.fennel
-;                ^^^ constant.language.fennel
-;                   ^^ punctuation.section.parens.end.fennel
-
 (match-try a
 ; <- punctuation.section.parens.begin.fennel
 ;^^^^^^^^^ entity.name.tag.fennel_support.fennel
@@ -323,48 +279,6 @@ _1 7/8 1_
 ;    ^ entity.name.tag.lua_support.fennel
 ;      ^^^^^ source.fennel
 ;           ^^ punctuation.section.parens.end.fennel
-
-(faccumulate [n 0 i 1 5] (+ n i))
-; <- punctuation.section.parens.begin.fennel
-;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
-;            ^ punctuation.section.brackets.begin.fennel
-;             ^ source.fennel
-;               ^ constant.numeric.integer.decimal.fennel
-;                 ^ source.fennel
-;                   ^ constant.numeric.integer.decimal.fennel
-;                     ^ constant.numeric.integer.decimal.fennel
-;                      ^ punctuation.section.brackets.end.fennel
-;                        ^ punctuation.section.parens.begin.fennel
-;                         ^ entity.name.tag.lua_support.fennel
-;                           ^^^ source.fennel
-;                              ^^ punctuation.section.parens.end.fennel
-
-(case [1 2 3]
-; <- punctuation.section.parens.begin.fennel
-;^^^^ entity.name.tag.fennel_support.fennel
-;     ^ punctuation.section.brackets.begin.fennel
-;      ^ constant.numeric.integer.decimal.fennel
-;        ^ constant.numeric.integer.decimal.fennel
-;          ^ constant.numeric.integer.decimal.fennel
-;           ^ punctuation.section.brackets.end.fennel
-  [a a]   (* a 2)
-; ^ punctuation.section.brackets.begin.fennel
-;  ^^^ source.fennel
-;     ^ punctuation.section.brackets.end.fennel
-;         ^ punctuation.section.parens.begin.fennel
-;          ^ entity.name.tag.lua_support.fennel
-;            ^ source.fennel
-;              ^ constant.numeric.integer.decimal.fennel
-;               ^ punctuation.section.parens.end.fennel
-  [1 b c] (+ b c))
-; ^ punctuation.section.brackets.begin.fennel
-;  ^ constant.numeric.integer.decimal.fennel
-;    ^^^ source.fennel
-;       ^ punctuation.section.brackets.end.fennel
-;         ^ punctuation.section.parens.begin.fennel
-;          ^ entity.name.tag.lua_support.fennel
-;            ^^^ source.fennel
-;               ^^ punctuation.section.parens.end.fennel
 
 (match [91 12 53]
 ; <- punctuation.section.parens.begin.fennel

--- a/tests/syntax_test_fennel_reference_130.fnl
+++ b/tests/syntax_test_fennel_reference_130.fnl
@@ -1,0 +1,93 @@
+; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
+
+; Fennel 1.3.0 on Lua 5.4.4
+
+; Deprecated:
+
+; New forms
+
+(fcollect [i 0 10 2]
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^ entity.name.tag.fennel_support.fennel
+;         ^ punctuation.section.brackets.begin.fennel
+;          ^ source.fennel
+;            ^ constant.numeric.integer.decimal.fennel
+;              ^^ constant.numeric.integer.decimal.fennel
+;                 ^ constant.numeric.integer.decimal.fennel
+;                  ^ punctuation.section.brackets.end.fennel
+  (if (> i 2) (* i i)))
+; ^ punctuation.section.parens.begin.fennel
+;  ^^ entity.name.tag.lua_support.fennel
+;     ^ punctuation.section.parens.begin.fennel
+;      ^ entity.name.tag.lua_support.fennel
+;        ^ source.fennel
+;          ^ constant.numeric.integer.decimal.fennel
+;           ^ punctuation.section.parens.end.fennel
+;             ^ punctuation.section.parens.begin.fennel
+;              ^ entity.name.tag.lua_support.fennel
+;                ^^^ source.fennel
+;                   ^^^ punctuation.section.parens.end.fennel
+
+(case-try a
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^ entity.name.tag.fennel_support.fennel
+;         ^ source.fennel
+  a {:a a}
+; ^ source.fennel
+;   ^ punctuation.section.braces.begin.fennel
+;    ^ punctuation.definition.keyword.fennel
+;     ^ constant.other.keyword.fennel
+;       ^ source.fennel
+;        ^ punctuation.section.braces.end.fennel
+  (catch
+; ^ punctuation.section.parens.begin.fennel
+;  ^^^^^ entity.name.tag.fennel_support.fennel
+    (_ :timeout) nil))
+;   ^ punctuation.section.parens.begin.fennel
+;    ^ variable.function.fennel
+;      ^ punctuation.definition.keyword.fennel
+;       ^^^^^^^ constant.other.keyword.fennel
+;                ^^^ constant.language.fennel
+;                   ^^ punctuation.section.parens.end.fennel
+
+(faccumulate [n 0 i 1 5] (+ n i))
+; <- punctuation.section.parens.begin.fennel
+;^^^^^^^^^^^ entity.name.tag.fennel_support.fennel
+;            ^ punctuation.section.brackets.begin.fennel
+;             ^ source.fennel
+;               ^ constant.numeric.integer.decimal.fennel
+;                 ^ source.fennel
+;                   ^ constant.numeric.integer.decimal.fennel
+;                     ^ constant.numeric.integer.decimal.fennel
+;                      ^ punctuation.section.brackets.end.fennel
+;                        ^ punctuation.section.parens.begin.fennel
+;                         ^ entity.name.tag.lua_support.fennel
+;                           ^^^ source.fennel
+;                              ^^ punctuation.section.parens.end.fennel
+
+(case [1 2 3]
+; <- punctuation.section.parens.begin.fennel
+;^^^^ entity.name.tag.fennel_support.fennel
+;     ^ punctuation.section.brackets.begin.fennel
+;      ^ constant.numeric.integer.decimal.fennel
+;        ^ constant.numeric.integer.decimal.fennel
+;          ^ constant.numeric.integer.decimal.fennel
+;           ^ punctuation.section.brackets.end.fennel
+  [a a]   (* a 2)
+; ^ punctuation.section.brackets.begin.fennel
+;  ^^^ source.fennel
+;     ^ punctuation.section.brackets.end.fennel
+;         ^ punctuation.section.parens.begin.fennel
+;          ^ entity.name.tag.lua_support.fennel
+;            ^ source.fennel
+;              ^ constant.numeric.integer.decimal.fennel
+;               ^ punctuation.section.parens.end.fennel
+  [1 b c] (+ b c))
+; ^ punctuation.section.brackets.begin.fennel
+;  ^ constant.numeric.integer.decimal.fennel
+;    ^^^ source.fennel
+;       ^ punctuation.section.brackets.end.fennel
+;         ^ punctuation.section.parens.begin.fennel
+;          ^ entity.name.tag.lua_support.fennel
+;            ^^^ source.fennel
+;               ^^ punctuation.section.parens.end.fennel

--- a/tests/syntax_test_fennel_reference_161.fnl
+++ b/tests/syntax_test_fennel_reference_161.fnl
@@ -1,0 +1,78 @@
+; SYNTAX TEST "Packages/Fennel/Fennel.sublime-syntax"
+
+; Fennel 1.6.0 on Lua 5.5.0
+
+; Deprecated:
+
+; New forms
+
+; tail!
+; it asserts that the argument is called in tail position
+; (since 1.4.0)
+
+(fn process-stuff [raw i]
+; <- punctuation.section.parens.begin.fennel
+;^^  storage.modifier.fn.fennel
+;   ^^^^^^^^^^^^^ entity.name.function.fn.fennel
+;                 ^ punctuation.section.brackets.begin.fennel
+;                  ^^^^^ source.fennel
+;                       ^ punctuation.section.brackets.end.fennel
+  (when (< i 10)
+; ^ punctuation.section.parens.begin.fennel
+;  ^^^^ entity.name.tag.fennel_support.fennel
+;       ^ punctuation.section.parens.begin.fennel
+;        ^ entity.name.tag.lua_support.fennel
+;          ^^ source.fennel
+;            ^^ constant.numeric.integer.decimal.fennel
+;              ^ punctuation.section.parens.end.fennel
+    (tail! (process-stuff raw (+ i 1)))))
+;   ^ punctuation.section.parens.begin.fennel
+;    ^^^^^ entity.name.tag.fennel_support.fennel
+;          ^ punctuation.section.parens.begin.fennel
+;           ^^^^^^^^^^^^^^^^^^ source.fennel
+;                             ^ punctuation.section.parens.begin.fennel
+;                              ^ entity.name.tag.lua_support.fennel
+;                                ^^ source.fennel
+;                                  ^ constant.numeric.integer.decimal.fennel
+;                                   ^^^^^ punctuation.section.parens.end.fennel
+
+; assert-repl
+; make an assertation which opens a repl when it fails.
+; (since 1.4.0)
+
+(let [input (get-input)
+; <- punctuation.section.parens.begin.fennel
+;^^^ entity.name.tag.let.fennel
+;    ^ punctuation.section.brackets.begin.fennel
+;     ^^^^^^ source.fennel
+;           ^ punctuation.section.parens.begin.fennel
+;            ^^^^^^^^^ source.fennel
+;                     ^ punctuation.section.parens.end.fennel
+      value []]
+;     ^^^^^^ source.fennel
+;           ^ punctuation.section.brackets.begin.fennel
+;            ^^ punctuation.section.brackets.end.fennel
+  (fn helper [x]
+; ^ punctuation.section.parens.begin.fennel
+;  ^^ storage.modifier.fn.fennel
+;     ^^^^^^ entity.name.function.fn.fennel
+;            ^ punctuation.section.brackets.begin.fennel
+;             ^ source.fennel
+;              ^ punctuation.section.brackets.end.fennel
+    (table.insert value (calculate x)))
+;   ^ punctuation.section.parens.begin.fennel
+;    ^^^^^^^^^^^^ entity.name.tag.lua_support.fennel
+;                 ^^^^^ source.fennel
+;                       ^ punctuation.section.parens.begin.fennel
+;                        ^^^^^^^^^^^ source.fennel
+;                                   ^^^ punctuation.section.parens.end.fennel
+  (assert-repl (transform helper value) "could not transform"))
+; ^ punctuation.section.parens.begin.fennel
+;  ^^^^^^^^^^^
+;              ^ punctuation.section.parens.begin.fennel
+;               ^^^^^^^^^^^^^^^^^^^^^^ source.fennel
+;                                     ^ punctuation.section.parens.end.fennel
+;                                       ^ punctuation.definition.string.begin.fennel
+;                                        ^^^^^^^^^^^^^^^^^^^ string.quoted.double.fennel
+;                                                           ^ punctuation.definition.string.end.fennel
+;                                                            ^^ punctuation.section.parens.end.fennel

--- a/tests/syntax_test_lua.fnl
+++ b/tests/syntax_test_lua.fnl
@@ -1959,6 +1959,20 @@
 ;                    ^ constant.numeric.integer.decimal.fennel
 ;                     ^^ punctuation.section.parens.end.fennel
 
+(print table.create)
+; <- punctuation.section.parens.begin.fennel
+;^^^^^ entity.name.tag.lua_support.fennel
+;      ^^^^^^^^^^^^ variable.language.lua_constant.fennel
+;                  ^ punctuation.section.parens.end.fennel
+
+(print (table.create 1))
+; <- punctuation.section.parens.begin.fennel
+;^^^^^ entity.name.tag.lua_support.fennel
+;      ^ punctuation.section.parens.begin.fennel
+;       ^^^^^^^^^^^^ entity.name.tag.lua_support.fennel
+;                    ^ constant.numeric.integer.decimal.fennel
+;                     ^^ punctuation.section.parens.end.fennel
+
 (print table.insert)
 ; <- punctuation.section.parens.begin.fennel
 ;^^^^^ entity.name.tag.lua_support.fennel


### PR DESCRIPTION
Hi,

this pull request:
* adds the new fennel functions added since 1.3.0
* adds `table.create` for Lua 5.5.0
* adds the tests
* moved the tests I added in my PR in 2023, to a separate testfile (I obviously didn't understand the file naming at this point. :D)
* updated the workflow.yml